### PR TITLE
Chore: add npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ include the lit.css file in the src directory. Otherwise, use the dist/lit.css f
 ## Development Setup
 1. Clone this repository (https://www.github.com/ajusa/lit)
 2. Make sure you have [npm](https://www.npmjs.com/get-npm) installed
-3. Run `npm install` in the root directory of lit
-4. Install [gulp](https://github.com/gulpjs/gulp) **globally**. You will need to make sure that the `-g` flag is in the command, like `npm install -g gulp@next`
-5. Once that is completed, run `gulp` to build the minified version and the gzipped file.
-6. If you are making changes live, use `gulp watch`. `watch` will build the minified css file in dist whenever there is a change in `src/lit.css`.
+3. Run `npm install` in the root directory of `lit`
+4. Once that is completed, run `npm run build` to build the minified version and the gzipped file.
+5. If you are making changes live, use `npm run watch`. `watch` will build the minified css file in `./dist` whenever there is a change in `./src/lit.css`.
 
 [Docs](https://ajusa.github.io/lit/)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "a sub 600 byte css framework",
   "main": "lit.css",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "gulp",
+    "watch": "gulp watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Actually you have done everything right in https://github.com/Ajusa/lit/issues/5#issuecomment-355965222. I just assume you have called the scripts wrongly. Once you have set up your npm scripts, you also have to call them as such. In this PR I introduced the scripts `watch` and `build`. These should be executed as `npm run watch` or `npm run build` (as I mentioned in the Dev Setup).

Just a hint, if you want to test that `gulp` is running in your npm scripts, you can write `./node_modules/.bin/gulp` into your shell. As in `./node_modules/.bin` are all modules which are executable within your npm script (hope this was not confusing).

Here I added a screenshot to illustrate it. In the first section I ran `gulp`, but `gulp` is not installed globally - so the command is unknown. In the second part, I ran `gulp` via the local `node_modules`. And in the third part, I run everything in the npm scripts, where nothing is installed globally now. But this does not mean you can't have a globally version of `gulp` as well 👍 

<img width="419" alt="screen shot 2018-01-08 at 18 19 10" src="https://user-images.githubusercontent.com/10677263/34682842-742e56ce-f4a0-11e7-8926-55b6abe7aca0.png">

Btw, within your Dev Docs I changed the path in (now) point 5. I just added a `./` before, so it is obvious that it is a directory in the root.
